### PR TITLE
Checking validity of index logged as Error fixes

### DIFF
--- a/Example/Tests/MutableLogicalMatrixTests.swift
+++ b/Example/Tests/MutableLogicalMatrixTests.swift
@@ -55,4 +55,30 @@ class MutableLogicalMatrixTests: XCTestCase {
             XCTAssertFalse((hMatrix[index, 0]!))
         }
     }
+    
+    func test_givenOutOfBoundsIndex_whenCheckValidity_thenItShouldReturnFalse() {
+        var vMatrix = VMutableLogicalMatrix(width: 5)
+        var hMatrix = HMutableLogicalMatrix(height: 5)
+        for index in 0..<6 {
+            vMatrix[1, index] = Bool.random()
+            hMatrix[index, 1] = Bool.random()
+            XCTAssertFalse(vMatrix.isValid(0, index + 1))
+            XCTAssertFalse(vMatrix.isValid(1, index + 1))
+            XCTAssertFalse(hMatrix.isValid(index + 1, 0))
+            XCTAssertFalse(hMatrix.isValid(index + 1, 1))
+        }
+    }
+    
+    func test_givenValidIndex_whenCheckValidity_thenItShouldReturnTrue() {
+        var vMatrix = VMutableLogicalMatrix(width: 5)
+        var hMatrix = HMutableLogicalMatrix(height: 5)
+        for index in 0..<6 {
+            vMatrix[1, index] = Bool.random()
+            hMatrix[index, 1] = Bool.random()
+            XCTAssertTrue(vMatrix.isValid(0, index))
+            XCTAssertTrue(vMatrix.isValid(1, index))
+            XCTAssertTrue(hMatrix.isValid(index, 0))
+            XCTAssertTrue(hMatrix.isValid(index, 1))
+        }
+    }
 }

--- a/MosaicGrid/Classes/Layout/MosaicGridLayout.swift
+++ b/MosaicGrid/Classes/Layout/MosaicGridLayout.swift
@@ -159,7 +159,7 @@ extension MosaicGridLayout where Cache == MosaicGridLayoutCache {
                 
                 let toFills = item.mapToGridCoordinate(startFrom: coordinate)
                 
-                guard toFills.isValid(in: mutableMatrix) else { continue }
+                guard toFills.isValidToFill(matrix: mutableMatrix) else { continue }
                 
                 toFills.forEach { coordinate in
                     mutableMatrix[coordinate.x, coordinate.y] = true
@@ -179,8 +179,8 @@ extension MosaicGridLayout where Cache == MosaicGridLayoutCache {
 // MARK: Private Extensions
 
 private extension Sequence where Element == MosaicGridCoordinate {
-    func isValid(in matrix: MutableLogicalMatrix) -> Bool {
-        for coordinate in self {
+    func isValidToFill(matrix: MutableLogicalMatrix) -> Bool {
+        for coordinate in self where matrix.isValid(coordinate.x, coordinate.y) {
             let isFilled = matrix[coordinate.x, coordinate.y] ?? false
             if isFilled { return false }
         }

--- a/MosaicGrid/Classes/Model/MutableLogicalMatrix.swift
+++ b/MosaicGrid/Classes/Model/MutableLogicalMatrix.swift
@@ -11,6 +11,7 @@ protocol MutableLogicalMatrix {
     var width: Int { get }
     var height: Int { get }
     subscript(_ column: Int, _ row: Int) -> Bool? { get set }
+    func isValid(_ column: Int, _ row: Int) -> Bool
 }
 
 struct VMutableLogicalMatrix: MutableLogicalMatrix {
@@ -48,6 +49,13 @@ struct VMutableLogicalMatrix: MutableLogicalMatrix {
             twoDArray[row][column] = newValue ?? false
         }
     }
+    
+    func isValid(_ column: Int, _ row: Int) -> Bool {
+        guard let rowArray = twoDArray[safe: row] else {
+            return false
+        }
+        return rowArray.count > column
+    }
 }
 
 struct HMutableLogicalMatrix: MutableLogicalMatrix {
@@ -84,5 +92,12 @@ struct HMutableLogicalMatrix: MutableLogicalMatrix {
             }
             twoDArray[column][row] = newValue ?? false
         }
+    }
+    
+    func isValid(_ column: Int, _ row: Int) -> Bool {
+        guard let columnArray = twoDArray[safe: column] else {
+            return false
+        }
+        return columnArray.count > row
     }
 }


### PR DESCRIPTION
- Add separate `isValid` check in `MutableLogicalMatrix`.
- Use isValid to check validity of index instead of using direct subscript.