### PR TITLE
chore: Bump version to 2.1.0 and update installation instructions.

### DIFF
--- a/MosaicGrid.podspec
+++ b/MosaicGrid.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MosaicGrid'
-  s.version          = '2.0.2'
+  s.version          = '2.1.0'
   s.summary          = 'MosaicGrid is a SwiftUI library that provides both horizontal and vertical mosaic grid views.'
 
 # This description is used to generate tags and improve search results.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 You can easily install MosaicGrid via [CocoaPods](https://cocoapods.org). Add the following line to your Podfile:
 
 ```ruby
-pod 'MosaicGrid', '~> 2.0.2'
+pod 'MosaicGrid', '~> 2.1'
 ```
 
 ### Swift Package Manager (Xcode)
@@ -42,7 +42,7 @@ To install using Xcode's Swift Package Manager, follow these steps:
 
 - Go to **File > Swift Package > Add Package Dependency**
 - Enter the URL: **<https://github.com/hainayanda/MosaicGrid.git>**
-- Choose **Up to Next Major** for the version rule and set the version to **2.0.2**.
+- Choose **Up to Next Major** for the version rule and set the version to **2.1.0**.
 - Click "Next" and wait for the package to be fetched.
 
 ### Swift Package Manager (Package.swift)
@@ -51,7 +51,7 @@ If you prefer using Package.swift, add MosaicGrid as a dependency in your **Pack
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hainayanda/MosaicGrid.git", .upToNextMajor(from: "2.0.2"))
+    .package(url: "https://github.com/hainayanda/MosaicGrid.git", .upToNextMajor(from: "2.1.0"))
 ]
 ```
 


### PR DESCRIPTION
This pull request updates the version of the `MosaicGrid` library to 2.1.0 and ensures all installation instructions reflect this new version. The changes help users install the latest release using CocoaPods or Swift Package Manager.

Version update:

* Bumped the version in the `MosaicGrid.podspec` file from `2.0.2` to `2.1.0`.

Documentation updates:

* Updated the CocoaPods installation instructions in `README.md` to use `~> 2.1` instead of `~> 2.0.2`.
* Updated Swift Package Manager instructions in `README.md` to reference version `2.1.0` instead of `2.0.2`, both in the Xcode UI steps and in the `Package.swift` example. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54)